### PR TITLE
feat: add endpoint to retrieve unresolved sessions

### DIFF
--- a/chat_service/model/chat.py
+++ b/chat_service/model/chat.py
@@ -21,5 +21,6 @@ class ChatMessage(Base):
     timestamp: Mapped[datetime] = mapped_column(server_default=func.current_timestamp())
     content: Mapped[str]
     author_type: Mapped[AuthorType] = mapped_column(SQLAlchemyEnum(AuthorType))
+    is_resolution: Mapped[bool] = mapped_column(default=False)
 
     session_id: Mapped[UUID]

--- a/chat_service/services.py
+++ b/chat_service/services.py
@@ -1,8 +1,10 @@
 """A module to provide functionalities to manage chat sessions."""
 
+from itertools import groupby
+from operator import attrgetter
 from uuid import UUID, uuid4
 
-from sqlalchemy import exists, select
+from sqlalchemy import and_, exists, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from chat_service.config import settings
@@ -14,6 +16,13 @@ from chat_service.transport import ChatSessionResponse
 class SessionNotFoundError(Exception):
     def __init__(self, session_id: UUID) -> None:
         super().__init__(f"Session {session_id} not found")
+
+
+class SessionResolvedError(Exception):
+    def __init__(self, session_id: UUID) -> None:
+        super().__init__(
+            f"Cannot add new message. Session {session_id} is already resolved."
+        )
 
 
 class ChatSessionManager:
@@ -40,30 +49,35 @@ class ChatSessionManager:
         return await self.get_session(new_session_id)
 
     async def add_message_to_session(
-        self, session_id: UUID, message_content: str, author_type: AuthorType
+        self,
+        session_id: UUID,
+        message_content: str,
+        author_type: AuthorType,
+        is_resolution: bool,
     ) -> ChatSessionResponse:
         """
         Add a message to an existing session.
 
         This will fail with a SessionNotFoundError if the session does not exist.
         """
-        exists_query = select(1).where(
-            exists().where(ChatMessage.session_id == session_id)
-        )
-        if not (await self.session.scalar(exists_query)):
-            raise SessionNotFoundError(session_id)
+        chat_session = await self.get_session(session_id)
+
+        if chat_session.is_resolved:
+            raise SessionResolvedError(chat_session.id)
 
         new_message = ChatMessage(
             id=uuid4(),
             session_id=session_id,
             content=message_content,
             author_type=author_type,
+            is_resolution=is_resolution,
         )
         self.session.add(new_message)
 
         await self.session.flush()
 
-        return await self.get_session(session_id)
+        chat_session.add_message(new_message)
+        return chat_session
 
     async def get_session(self, session_id: UUID) -> ChatSessionResponse:
         """
@@ -77,3 +91,28 @@ class ChatSessionManager:
         if not messages:
             raise SessionNotFoundError(session_id)
         return ChatSessionResponse.from_chat_messages(messages)
+
+    async def get_unresolved_sessions(self) -> list[ChatSessionResponse]:
+        # find all session ids for which no resolving message exists
+        unresolved_sessions_query = (
+            select(ChatMessage)
+            .where(
+                ~exists().where(
+                    and_(
+                        ChatMessage.session_id == ChatMessage.session_id,
+                        ChatMessage.is_resolution == True,  # noqa
+                    )
+                )
+            )
+            .order_by(ChatMessage.session_id, ChatMessage.timestamp)
+        )
+        unresolved_sessions = await self.session.scalars(unresolved_sessions_query)
+
+        # parse the individual sessions
+        session_responses: list[ChatSessionResponse] = []
+        for session_id, messages in groupby(
+            unresolved_sessions, attrgetter("session_id")
+        ):
+            session_responses.append(ChatSessionResponse.from_chat_messages(messages))
+
+        return session_responses

--- a/migrations/versions/02_1bcfd5c7736c_add_resolution_column.py
+++ b/migrations/versions/02_1bcfd5c7736c_add_resolution_column.py
@@ -19,9 +19,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "chat_messages", sa.Column("is_resolution", sa.Boolean(), nullable=False)
-    )
+    op.add_column("chat_messages", sa.Column("is_resolution", sa.Boolean(), nullable=True))
+    op.execute("UPDATE chat_messages SET is_resolution = false")
+    op.alter_column("chat_messages", "is_resolution", nullable=False)
 
 
 def downgrade() -> None:

--- a/migrations/versions/02_1bcfd5c7736c_add_resolution_column.py
+++ b/migrations/versions/02_1bcfd5c7736c_add_resolution_column.py
@@ -1,0 +1,28 @@
+"""add resolution column
+
+Revision ID: 1bcfd5c7736c
+Revises: 9018b4fb75f3
+Create Date: 2024-09-02 22:38:31.264043
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1bcfd5c7736c"
+down_revision: Union[str, None] = "9018b4fb75f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_messages", sa.Column("is_resolution", sa.Boolean(), nullable=False)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_messages", "is_resolution")


### PR DESCRIPTION
Extend the data model to support resolving chat sessions and an endpoint to retrieve unresolved chat sessions.